### PR TITLE
Add support for get_throttled command

### DIFF
--- a/collector/throttled.go
+++ b/collector/throttled.go
@@ -1,0 +1,42 @@
+package collector
+
+import (
+	"github.com/derknerd/raspberry-exporter/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"regexp"
+	"strconv"
+)
+
+const (
+	Throttled string = "get_throttled"
+)
+
+var (
+	throttledRegex = regexp.MustCompile(`(throttled=)|(0x)|(\n)|(\r)`)
+)
+
+func (c *VcGenCmdCollector) getThrottledAtBit(desc *prometheus.Desc, atBit uint, device string) prometheus.Metric {
+	bits, err := utils.ExecuteVcGen(c.VcGenCmd, "get_throttled", device)
+
+	if err != nil {
+		return prometheus.NewInvalidMetric(desc, err)
+	}
+
+	bits = throttledRegex.ReplaceAllString(bits, "")
+	bitsUInt, err := strconv.ParseUint(bits, 16, 64)
+	bitBool := 0.0
+	if bitsUInt&(1<<atBit) == 0 {
+		bitBool = 0
+	} else {
+		bitBool = 1
+	}
+	if err != nil {
+		return prometheus.NewInvalidMetric(desc, err)
+	}
+
+	return prometheus.MustNewConstMetric(
+		desc,
+		prometheus.GaugeValue,
+		bitBool,
+	)
+}

--- a/collector/vcgencmcollector.go
+++ b/collector/vcgencmcollector.go
@@ -66,6 +66,30 @@ var (
 		nil,
 		nil,
 	)
+	throttledUnderVoltageDetectedDesc = prometheus.NewDesc(
+		prefix+"throttled_under_voltage_detected",
+		"Under-voltage detected",
+		nil,
+		nil,
+	)
+	throttledArmFrequencyCappedDesc = prometheus.NewDesc(
+		prefix+"throttled_arm_freq_capped",
+		"Arm frequency capped",
+		nil,
+		nil,
+	)
+	throttledCurrentlyThrottled = prometheus.NewDesc(
+		prefix+"throttled_currently_throttled",
+		"Currently throttled",
+		nil,
+		nil,
+	)
+	throttledSoftTemperatureLimitActive = prometheus.NewDesc(
+		prefix+"throttled_soft_temperature_limit_active",
+		"Soft temperature limit active",
+		nil,
+		nil,
+	)
 )
 
 type VcGenCmdCollector struct {
@@ -83,6 +107,10 @@ func (c *VcGenCmdCollector) Describe(channel chan<- *prometheus.Desc) {
 	channel <- emmcClockDesc
 	channel <- cpuMemoryDesc
 	channel <- gpuMemoryDesc
+	channel <- throttledUnderVoltageDetectedDesc
+	channel <- throttledArmFrequencyCappedDesc
+	channel <- throttledCurrentlyThrottled
+	channel <- throttledSoftTemperatureLimitActive
 }
 
 func (c *VcGenCmdCollector) Collect(channel chan<- prometheus.Metric) {
@@ -96,6 +124,10 @@ func (c *VcGenCmdCollector) Collect(channel chan<- prometheus.Metric) {
 	channel <- c.getClock(emmcClockDesc, EmmcClock)
 	channel <- c.getMemory(cpuMemoryDesc, CpuMemory)
 	channel <- c.getMemory(gpuMemoryDesc, GpuMemory)
+	channel <- c.getThrottledAtBit(throttledUnderVoltageDetectedDesc, 0, Throttled)
+	channel <- c.getThrottledAtBit(throttledArmFrequencyCappedDesc, 1, Throttled)
+	channel <- c.getThrottledAtBit(throttledCurrentlyThrottled, 2, Throttled)
+	channel <- c.getThrottledAtBit(throttledSoftTemperatureLimitActive, 3, Throttled)
 }
 
 func NewVcGenCmdCollector(vcGenCmd string) *VcGenCmdCollector {


### PR DESCRIPTION
Spec: https://www.raspberrypi.org/documentation/raspbian/applications/vcgencmd.md

Example exports in `/metrics`

```
# HELP pi_vcgencmd_throttled_arm_freq_capped Arm frequency capped
# TYPE pi_vcgencmd_throttled_arm_freq_capped gauge
pi_vcgencmd_throttled_arm_freq_capped 0
# HELP pi_vcgencmd_throttled_currently_throttled Currently throttled
# TYPE pi_vcgencmd_throttled_currently_throttled gauge
pi_vcgencmd_throttled_currently_throttled 0
# HELP pi_vcgencmd_throttled_soft_temperature_limit_active Soft temperature limit active
# TYPE pi_vcgencmd_throttled_soft_temperature_limit_active gauge
pi_vcgencmd_throttled_soft_temperature_limit_active 0
# HELP pi_vcgencmd_throttled_under_voltage_detected Under-voltage detected
# TYPE pi_vcgencmd_throttled_under_voltage_detected gauge
pi_vcgencmd_throttled_under_voltage_detected 0
```

Where 0 is equivalent to false, 1 is equivalent to true.

Thank you for making this wonderful project! If you have any question, please ask.