### PR TITLE
support for older raspi installations

### DIFF
--- a/app.go
+++ b/app.go
@@ -18,7 +18,7 @@ func main() {
 		log.Fatalf("Error loading configuration: %s", err)
 	}
 
-	c := collector.NewVcGenCmdCollector(config.Raspberry.VcGenCmd)
+	c := collector.NewVcGenCmdCollector(config.Raspberry)
 	prometheus.MustRegister(c)
 
 	listenAddress := config.Listen.Address

--- a/collector/vcgencmcollector.go
+++ b/collector/vcgencmcollector.go
@@ -1,99 +1,150 @@
 package collector
 
 import (
+	"io/ioutil"
+	"log"
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
+    "github.com/derknerd/raspberry-exporter/utils"
 )
+
+func getModel(cfg utils.RaspberryConfig) string {
+    if cfg.Model != "" {
+        return cfg.Model
+    }
+	data, err := ioutil.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		log.Printf("failed to read /proc/cpuinfo: %s", err)
+		return "unknown"
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "Model\t") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+    return "unknown"
+}
+
 
 var (
 	prefix       = "pi_vcgencmd_"
+    coreTempDesc *prometheus.Desc
+    coreVoltageDesc *prometheus.Desc
+    sdramControllerVoltageDesc *prometheus.Desc
+    sdramInputOutputVoltageDesc *prometheus.Desc
+    sdramPhysicalVoltageDesc *prometheus.Desc
+    coreClockDesc *prometheus.Desc
+    armClockDesc *prometheus.Desc
+    emmcClockDesc *prometheus.Desc
+    cpuMemoryDesc *prometheus.Desc
+    gpuMemoryDesc *prometheus.Desc
+    throttledUnderVoltageDetectedDesc *prometheus.Desc
+    throttledArmFrequencyCappedDesc *prometheus.Desc
+    throttledCurrentlyThrottled *prometheus.Desc
+    throttledSoftTemperatureLimitActive *prometheus.Desc
+)
+
+func initDescriptions(model string) {
+
+    constLabels := prometheus.Labels {
+        "model": model,
+    }
+
 	coreTempDesc = prometheus.NewDesc(
 		prefix+"core_temp",
 		"Temperature of the SoC",
 		nil,
-		nil,
+		constLabels,
 	)
 	coreVoltageDesc = prometheus.NewDesc(
 		prefix+"core_voltage",
 		"Voltage of the CPU",
 		nil,
-		nil,
+		constLabels,
 	)
 	sdramControllerVoltageDesc = prometheus.NewDesc(
 		prefix+"sdram_controller_voltage",
 		"Voltage of the SDRAM controller",
 		nil,
-		nil,
+		constLabels,
 	)
 	sdramInputOutputVoltageDesc = prometheus.NewDesc(
 		prefix+"sdram_input_output_voltage",
 		"Voltage of the SDRAM IO",
 		nil,
-		nil,
+		constLabels,
 	)
 	sdramPhysicalVoltageDesc = prometheus.NewDesc(
 		prefix+"sdram_physical_voltage",
 		"Voltage of the physical SDRAM",
 		nil,
-		nil,
+		constLabels,
 	)
 	coreClockDesc = prometheus.NewDesc(
 		prefix+"gpu_clock",
 		"Clock speed of the GPU in Hz",
 		nil,
-		nil,
+		constLabels,
 	)
 	armClockDesc = prometheus.NewDesc(
 		prefix+"cpu_clock",
 		"Clock speed of the ARM CPU in Hz",
 		nil,
-		nil,
+		constLabels,
 	)
 	emmcClockDesc = prometheus.NewDesc(
 		prefix+"emmc_clock",
 		"Clock speed of the SD card in Hz",
 		nil,
-		nil,
+		constLabels,
 	)
 	cpuMemoryDesc = prometheus.NewDesc(
 		prefix+"cpu_memory",
 		"Memory for the CPU in Megabytes",
 		nil,
-		nil,
+		constLabels,
 	)
 	gpuMemoryDesc = prometheus.NewDesc(
 		prefix+"gpu_memory",
 		"Memory for the GPU in Megabytes",
 		nil,
-		nil,
+		constLabels,
 	)
 	throttledUnderVoltageDetectedDesc = prometheus.NewDesc(
 		prefix+"throttled_under_voltage_detected",
 		"Under-voltage detected",
 		nil,
-		nil,
+		constLabels,
 	)
 	throttledArmFrequencyCappedDesc = prometheus.NewDesc(
 		prefix+"throttled_arm_freq_capped",
 		"Arm frequency capped",
 		nil,
-		nil,
+		constLabels,
 	)
 	throttledCurrentlyThrottled = prometheus.NewDesc(
 		prefix+"throttled_currently_throttled",
 		"Currently throttled",
 		nil,
-		nil,
+		constLabels,
 	)
 	throttledSoftTemperatureLimitActive = prometheus.NewDesc(
 		prefix+"throttled_soft_temperature_limit_active",
 		"Soft temperature limit active",
 		nil,
-		nil,
+		constLabels,
 	)
-)
+}
 
 type VcGenCmdCollector struct {
-	VcGenCmd string
+	VcGenCmd         string
+	DisableThrottled bool
 }
 
 func (c *VcGenCmdCollector) Describe(channel chan<- *prometheus.Desc) {
@@ -107,10 +158,12 @@ func (c *VcGenCmdCollector) Describe(channel chan<- *prometheus.Desc) {
 	channel <- emmcClockDesc
 	channel <- cpuMemoryDesc
 	channel <- gpuMemoryDesc
-	channel <- throttledUnderVoltageDetectedDesc
-	channel <- throttledArmFrequencyCappedDesc
-	channel <- throttledCurrentlyThrottled
-	channel <- throttledSoftTemperatureLimitActive
+	if !c.DisableThrottled {
+		channel <- throttledUnderVoltageDetectedDesc
+		channel <- throttledArmFrequencyCappedDesc
+		channel <- throttledCurrentlyThrottled
+		channel <- throttledSoftTemperatureLimitActive
+	}
 }
 
 func (c *VcGenCmdCollector) Collect(channel chan<- prometheus.Metric) {
@@ -124,14 +177,19 @@ func (c *VcGenCmdCollector) Collect(channel chan<- prometheus.Metric) {
 	channel <- c.getClock(emmcClockDesc, EmmcClock)
 	channel <- c.getMemory(cpuMemoryDesc, CpuMemory)
 	channel <- c.getMemory(gpuMemoryDesc, GpuMemory)
-	channel <- c.getThrottledAtBit(throttledUnderVoltageDetectedDesc, 0, Throttled)
-	channel <- c.getThrottledAtBit(throttledArmFrequencyCappedDesc, 1, Throttled)
-	channel <- c.getThrottledAtBit(throttledCurrentlyThrottled, 2, Throttled)
-	channel <- c.getThrottledAtBit(throttledSoftTemperatureLimitActive, 3, Throttled)
+	if !c.DisableThrottled {
+		channel <- c.getThrottledAtBit(throttledUnderVoltageDetectedDesc, 0, Throttled)
+		channel <- c.getThrottledAtBit(throttledArmFrequencyCappedDesc, 1, Throttled)
+		channel <- c.getThrottledAtBit(throttledCurrentlyThrottled, 2, Throttled)
+		channel <- c.getThrottledAtBit(throttledSoftTemperatureLimitActive, 3, Throttled)
+	}
 }
 
-func NewVcGenCmdCollector(vcGenCmd string) *VcGenCmdCollector {
+func NewVcGenCmdCollector(cfg utils.RaspberryConfig) *VcGenCmdCollector {
+    model := getModel(cfg)
+    initDescriptions(model)
 	return &VcGenCmdCollector{
-		VcGenCmd: vcGenCmd,
+		VcGenCmd:         cfg.VcGenCmd,
+		DisableThrottled: cfg.DisableThrottled,
 	}
 }

--- a/collector/vcgencmcollector.go
+++ b/collector/vcgencmcollector.go
@@ -5,14 +5,14 @@ import (
 	"log"
 	"strings"
 
+	"github.com/derknerd/raspberry-exporter/utils"
 	"github.com/prometheus/client_golang/prometheus"
-    "github.com/derknerd/raspberry-exporter/utils"
 )
 
 func getModel(cfg utils.RaspberryConfig) string {
-    if cfg.Model != "" {
-        return cfg.Model
-    }
+	if cfg.Model != "" {
+		return cfg.Model
+	}
 	data, err := ioutil.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		log.Printf("failed to read /proc/cpuinfo: %s", err)
@@ -28,33 +28,32 @@ func getModel(cfg utils.RaspberryConfig) string {
 			return strings.TrimSpace(parts[1])
 		}
 	}
-    return "unknown"
+	return "unknown"
 }
 
-
 var (
-	prefix       = "pi_vcgencmd_"
-    coreTempDesc *prometheus.Desc
-    coreVoltageDesc *prometheus.Desc
-    sdramControllerVoltageDesc *prometheus.Desc
-    sdramInputOutputVoltageDesc *prometheus.Desc
-    sdramPhysicalVoltageDesc *prometheus.Desc
-    coreClockDesc *prometheus.Desc
-    armClockDesc *prometheus.Desc
-    emmcClockDesc *prometheus.Desc
-    cpuMemoryDesc *prometheus.Desc
-    gpuMemoryDesc *prometheus.Desc
-    throttledUnderVoltageDetectedDesc *prometheus.Desc
-    throttledArmFrequencyCappedDesc *prometheus.Desc
-    throttledCurrentlyThrottled *prometheus.Desc
-    throttledSoftTemperatureLimitActive *prometheus.Desc
+	prefix                              = "pi_vcgencmd_"
+	coreTempDesc                        *prometheus.Desc
+	coreVoltageDesc                     *prometheus.Desc
+	sdramControllerVoltageDesc          *prometheus.Desc
+	sdramInputOutputVoltageDesc         *prometheus.Desc
+	sdramPhysicalVoltageDesc            *prometheus.Desc
+	coreClockDesc                       *prometheus.Desc
+	armClockDesc                        *prometheus.Desc
+	emmcClockDesc                       *prometheus.Desc
+	cpuMemoryDesc                       *prometheus.Desc
+	gpuMemoryDesc                       *prometheus.Desc
+	throttledUnderVoltageDetectedDesc   *prometheus.Desc
+	throttledArmFrequencyCappedDesc     *prometheus.Desc
+	throttledCurrentlyThrottled         *prometheus.Desc
+	throttledSoftTemperatureLimitActive *prometheus.Desc
 )
 
 func initDescriptions(model string) {
 
-    constLabels := prometheus.Labels {
-        "model": model,
-    }
+	constLabels := prometheus.Labels{
+		"model": model,
+	}
 
 	coreTempDesc = prometheus.NewDesc(
 		prefix+"core_temp",
@@ -186,8 +185,8 @@ func (c *VcGenCmdCollector) Collect(channel chan<- prometheus.Metric) {
 }
 
 func NewVcGenCmdCollector(cfg utils.RaspberryConfig) *VcGenCmdCollector {
-    model := getModel(cfg)
-    initDescriptions(model)
+	model := getModel(cfg)
+	initDescriptions(model)
 	return &VcGenCmdCollector{
 		VcGenCmd:         cfg.VcGenCmd,
 		DisableThrottled: cfg.DisableThrottled,

--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,7 @@ listen:
   metricspath: /metrics
 raspberry:
   vcgencmd: /usr/bin/vcgencmd
+  # for old vcgencmd you might want to set this to true:
+  disable_throttled: false
+  # when autodetection of the raspberry model fails, set this here:
+  # model: "Raspberry Pi 1 B"

--- a/utils/config.go
+++ b/utils/config.go
@@ -25,7 +25,9 @@ type ListenConfig struct {
 }
 
 type RaspberryConfig struct {
-	VcGenCmd string `yaml:"vcgencmd"`
+	VcGenCmd         string `yaml:"vcgencmd"`
+	DisableThrottled bool   `yaml:"disable_throttled"`
+    Model            string `yaml:"model"`
 }
 
 func ParseConfig() (*LocalConfig, error) {
@@ -67,7 +69,8 @@ func defaultConfig() (*LocalConfig, error) {
 
 	return &LocalConfig{
 		Raspberry: RaspberryConfig{
-			VcGenCmd: vcGenCmd,
+			VcGenCmd:         vcGenCmd,
+			DisableThrottled: false,
 		},
 		Listen: ListenConfig{
 			Address:     defaultListenAddress,

--- a/utils/config.go
+++ b/utils/config.go
@@ -27,7 +27,7 @@ type ListenConfig struct {
 type RaspberryConfig struct {
 	VcGenCmd         string `yaml:"vcgencmd"`
 	DisableThrottled bool   `yaml:"disable_throttled"`
-    Model            string `yaml:"model"`
+	Model            string `yaml:"model"`
 }
 
 func ParseConfig() (*LocalConfig, error) {


### PR DESCRIPTION
* add disable_throttled for vcgencmd which do not know about this
* add model (autodetect, also settable via config) as tag